### PR TITLE
Update 1-create-ca.md

### DIFF
--- a/1-bring-your-own-ca/1-create-ca.md
+++ b/1-bring-your-own-ca/1-create-ca.md
@@ -59,7 +59,7 @@ openssl req -x509 \
         -sha256 \
         -days 1024 \
         -out rootCA.pem \
-        -config openssl.cnf \
+        -config ~/openssl.cnf \
         -extensions ext
 ```
 Interactive Command Output, enter **Common Name** value of *My Test CA* on highlighted line:
@@ -105,7 +105,7 @@ Generating RSA private key, 2048 bit long modulus
 **Command Input:**
 
 ```bash
-openssl req -new -key verificationCert.key -out verificationCert.csr
+openssl req -new -key verificationCert.key -out verificationCert.csr -config ~/openssl.cnf
 ```
 
 Interactive Command Output, for the **Common Name** field, replace with your *registration code*, press enter for all others to accept defaults:


### PR DESCRIPTION
*Description of changes:*

There was one `openssl` command where the path to `openssl.conf` file was wrong, and another one where the path to that same file was missing (resulting in a CA certificate with a different `subject` value than the one expected and shown in the command output example).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
